### PR TITLE
FIX: undefined this.props.games

### DIFF
--- a/src/core/components/exercice-13-correction/Game/GameLibrary.jsx
+++ b/src/core/components/exercice-13-correction/Game/GameLibrary.jsx
@@ -12,7 +12,7 @@ export class GameLibrary extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.games.length === 0) {
+        if (this.state.games.length === 0) {
             fetch('http://localhost:5010/api/games')
                 .then(response => response.json())
                 .then(games => this.setState({ games }))


### PR DESCRIPTION
'/games' route doesn't work, due to undefined `this.props.games`
As we derivate `state.games`with `props.game`, a simple fix is to use state instead of props.