### PR TITLE
Refactor Game form

### DIFF
--- a/src/core/components/exercice-13-correction/Game/GameForm.jsx
+++ b/src/core/components/exercice-13-correction/Game/GameForm.jsx
@@ -11,24 +11,28 @@ export class GameForm extends React.Component {
         return {
             gameTitle: '',
             gameDescription: '',
-            gamePlatforms: [],
-            gameDevelopers: [],
-            gameGenders: [],
             gamePrice: 0,
             gameRating: 0,
-            gameReleaseDate: '',
-            gameThumbnail: '',
-            gameUpdatedAt: '',
         };
     }
 
+	handleOnChange(event) {
+		this.setState({ [ event.target.name ]: event.target.value })
+	}
+
     render() {
-        const { handleOnChange, handleOnSubmit } = this.props
+        const { handleOnSubmit } = this.props
 
         return <Bloc className='pure-u-12-24'>
             <Form className='pure-form pure-form-stacked' onSubmit={ e => {
-                new Promise(resolve => resolve(handleOnSubmit(e, this.state)))
-                    .then(() => this.setState(GameForm.initialState))
+            	e.preventDefault()
+                handleOnSubmit({
+					title: this.state.gameTitle,
+					description: this.state.gameDescription,
+					price: this.state.gamePrice,
+					rating: this.state.gameRating,
+				})
+				this.setState(GameForm.initialState)
             } }>
                 <Title>Add a new Game</Title>
                 <fieldset>
@@ -36,28 +40,28 @@ export class GameForm extends React.Component {
                         type='text'
                         value={ this.state.gameTitle }
                         name='gameTitle'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Title'
                     />
                     <Input
                         type='text'
                         value={ this.state.gameDescription }
                         name='gameDescription'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Description'
                     />
                     <Input
                         type='number'
                         value={ this.state.gamePrice }
                         name='gamePrice'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Price'
                     />
                     <Input
                         type='number'
                         value={ this.state.gameRating }
                         name='gameRating'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Rating'
                     />
                     <Button type='submit'

--- a/src/core/components/exercice-13-correction/Game/GameLibrary.jsx
+++ b/src/core/components/exercice-13-correction/Game/GameLibrary.jsx
@@ -6,9 +6,15 @@ export class GameLibrary extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            games: this.props.games ? this.props.games : [],
+            games: [],
             error: ''
         }
+    }
+
+    static getDerivedStateFromProps(nextProps, prevStates) {
+        return nextProps.games && prevStates.games !== nextProps.games ?
+            {games: nextProps.games} :
+            null;
     }
 
     componentDidMount() {

--- a/src/core/components/exercice-13-correction/Game/index.jsx
+++ b/src/core/components/exercice-13-correction/Game/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bloc, GameForm, GameLibrary, GameList } from '../index';
+import {Bloc, GameForm, GameLibrary} from '../index';
 
 export class GameStore extends React.Component {
     constructor(props) {
@@ -11,13 +11,14 @@ export class GameStore extends React.Component {
         }
     }
 
-    onInputValueChange(event) {
-        this.setState({ [ event.target.name ]: event.target.value })
+    componentDidMount() {
+        fetch('http://localhost:5010/api/games')
+            .then(response => response.json())
+            .then(games => this.setState({games}))
+            .catch(error => this.setState({error: error}))
     }
 
-    onFormSubmit(e, values) {
-        e.preventDefault()
-
+    onFormSubmit = (values) => {
         fetch('/api/game', {
             method: 'POST',
             headers: {
@@ -35,9 +36,16 @@ export class GameStore extends React.Component {
 
         return (
             <Bloc className={ className }>
-                <GameLibrary games={ this.state.games }/>
-                <GameForm handleOnChange={ this.onInputValueChange }
-                          handleOnSubmit={ this.onFormSubmit.bind(this) }/>
+                {
+                    this.state.error !== '' ?
+                        <Bloc className="fetchError">An error occurred, please come back later</Bloc> :
+                        this.state.games.length > 0 ? <GameLibrary games={this.state.games} className='gameList'/>:
+                            <Bloc className="listEmpty">No games to show :/</Bloc>
+                }
+
+                    <GameForm handleOnSubmit={values => this.onFormSubmit(values)}/>
+
+
             </Bloc>);
     }
 }

--- a/src/core/components/exercice-13/Game/GameForm.jsx
+++ b/src/core/components/exercice-13/Game/GameForm.jsx
@@ -11,24 +11,28 @@ export class GameForm extends React.Component {
         return {
             gameTitle: '',
             gameDescription: '',
-            gamePlatforms: [],
-            gameDevelopers: [],
-            gameGenders: [],
             gamePrice: 0,
             gameRating: 0,
-            gameReleaseDate: '',
-            gameThumbnail: '',
-            gameUpdatedAt: '',
         };
     }
 
+    handleOnChange(event) {
+        this.setState({ [ event.target.name ]: event.target.value })
+    }
+
     render() {
-        const { handleOnChange, handleOnSubmit } = this.props
+        const { handleOnSubmit } = this.props
 
         return <Bloc className='pure-u-12-24'>
             <Form className='pure-form pure-form-stacked' onSubmit={ e => {
-                new Promise(resolve => resolve(handleOnSubmit(e, this.state)))
-                    .then(() => this.setState(GameForm.initialState))
+                e.preventDefault()
+                handleOnSubmit({
+                    title: this.state.gameTitle,
+                    description: this.state.gameDescription,
+                    price: this.state.gamePrice,
+                    rating: this.state.gameRating,
+                })
+                this.setState(GameForm.initialState)
             } }>
                 <Title>Add a new Game</Title>
                 <fieldset>
@@ -36,28 +40,28 @@ export class GameForm extends React.Component {
                         type='text'
                         value={ this.state.gameTitle }
                         name='gameTitle'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Title'
                     />
                     <Input
                         type='text'
                         value={ this.state.gameDescription }
                         name='gameDescription'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Description'
                     />
                     <Input
                         type='number'
                         value={ this.state.gamePrice }
                         name='gamePrice'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Price'
                     />
                     <Input
                         type='number'
                         value={ this.state.gameRating }
                         name='gameRating'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Rating'
                     />
                     <Button type='submit'

--- a/src/core/components/exercice-13/Game/index.jsx
+++ b/src/core/components/exercice-13/Game/index.jsx
@@ -11,13 +11,7 @@ export class GameStore extends React.Component {
         }
     }
 
-    onInputValueChange(event) {
-        this.setState({ [ event.target.name ]: event.target.value })
-    }
-
-    onFormSubmit(e, values) {
-        e.preventDefault()
-
+    onFormSubmit(values) {
         fetch('/api/game', {
             method: 'POST',
             headers: {
@@ -48,7 +42,7 @@ export class GameStore extends React.Component {
                         <Bloc className="listEmpty">No games to show :/</Bloc>
                 }
             </Bloc>
-            <GameForm handleOnChange={ this.onInputValueChange }
+            <GameForm
                       handleOnSubmit={ this.onFormSubmit.bind(this) }/>
         </Bloc>
     }

--- a/src/core/components/exercice-14-A-correction/Game/GameForm.jsx
+++ b/src/core/components/exercice-14-A-correction/Game/GameForm.jsx
@@ -11,24 +11,28 @@ export class GameForm extends React.Component {
         return {
             gameTitle: '',
             gameDescription: '',
-            gamePlatforms: [],
-            gameDevelopers: [],
-            gameGenders: [],
             gamePrice: 0,
             gameRating: 0,
-            gameReleaseDate: '',
-            gameThumbnail: '',
-            gameUpdatedAt: '',
         };
     }
 
+	handleOnChange(event) {
+		this.setState({ [ event.target.name ]: event.target.value })
+	}
+
     render() {
-        const { handleOnChange, handleOnSubmit } = this.props
+        const { handleOnSubmit } = this.props
 
         return <Bloc className='pure-u-12-24'>
             <Form className='pure-form pure-form-stacked' onSubmit={ e => {
-                new Promise(resolve => resolve(handleOnSubmit(e, this.state)))
-                    .then(() => this.setState(GameForm.initialState))
+            	e.preventDefault()
+                handleOnSubmit({
+					title: this.state.gameTitle,
+					description: this.state.gameDescription,
+					price: this.state.gamePrice,
+					rating: this.state.gameRating,
+				})
+				this.setState(GameForm.initialState)
             } }>
                 <Title>Add a new Game</Title>
                 <fieldset>
@@ -36,28 +40,28 @@ export class GameForm extends React.Component {
                         type='text'
                         value={ this.state.gameTitle }
                         name='gameTitle'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Title'
                     />
                     <Input
                         type='text'
                         value={ this.state.gameDescription }
                         name='gameDescription'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Description'
                     />
                     <Input
                         type='number'
                         value={ this.state.gamePrice }
                         name='gamePrice'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Price'
                     />
                     <Input
                         type='number'
                         value={ this.state.gameRating }
                         name='gameRating'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Rating'
                     />
                     <Button type='submit'

--- a/src/core/components/exercice-14-A-correction/Game/GameLibrary.jsx
+++ b/src/core/components/exercice-14-A-correction/Game/GameLibrary.jsx
@@ -6,13 +6,19 @@ export class GameLibrary extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            games: this.props.games ? this.props.games : [],
+            games: [],
             error: ''
         }
     }
 
+    static getDerivedStateFromProps(nextProps, prevStates) {
+        return nextProps.games && prevStates.games !== nextProps.games ?
+            {games: nextProps.games} :
+            null;
+    }
+
     componentDidMount() {
-        if (this.props.games.length === 0) {
+        if (this.state.games.length === 0) {
             fetch('http://localhost:5010/api/games')
                 .then(response => response.json())
                 .then(games => this.setState({ games }))

--- a/src/core/components/exercice-14-A-correction/Game/index.jsx
+++ b/src/core/components/exercice-14-A-correction/Game/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bloc, GameForm, GameLibrary, GameList } from '../index';
+import {Bloc, GameForm, GameLibrary} from '../index';
 
 export class GameStore extends React.Component {
     constructor(props) {
@@ -11,13 +11,14 @@ export class GameStore extends React.Component {
         }
     }
 
-    onInputValueChange(event) {
-        this.setState({ [ event.target.name ]: event.target.value })
+    componentDidMount() {
+        fetch('http://localhost:5010/api/games')
+            .then(response => response.json())
+            .then(games => this.setState({games}))
+            .catch(error => this.setState({error: error}))
     }
 
-    onFormSubmit(e, values) {
-        e.preventDefault()
-
+    onFormSubmit = (values) => {
         fetch('/api/game', {
             method: 'POST',
             headers: {
@@ -35,9 +36,16 @@ export class GameStore extends React.Component {
 
         return (
             <Bloc className={ className }>
-                <GameLibrary games={ this.state.games }/>
-                <GameForm handleOnChange={ this.onInputValueChange }
-                          handleOnSubmit={ this.onFormSubmit.bind(this) }/>
+                {
+                    this.state.error !== '' ?
+                        <Bloc className="fetchError">An error occurred, please come back later</Bloc> :
+                        this.state.games.length > 0 ? <GameLibrary games={this.state.games} className='gameList'/>:
+                            <Bloc className="listEmpty">No games to show :/</Bloc>
+                }
+
+                    <GameForm handleOnSubmit={values => this.onFormSubmit(values)}/>
+
+
             </Bloc>);
     }
 }

--- a/src/core/components/exercice-14-A/Game/GameForm.jsx
+++ b/src/core/components/exercice-14-A/Game/GameForm.jsx
@@ -11,24 +11,28 @@ export class GameForm extends React.Component {
         return {
             gameTitle: '',
             gameDescription: '',
-            gamePlatforms: [],
-            gameDevelopers: [],
-            gameGenders: [],
             gamePrice: 0,
             gameRating: 0,
-            gameReleaseDate: '',
-            gameThumbnail: '',
-            gameUpdatedAt: '',
         };
     }
 
+	handleOnChange(event) {
+		this.setState({ [ event.target.name ]: event.target.value })
+	}
+
     render() {
-        const { handleOnChange, handleOnSubmit } = this.props
+        const { handleOnSubmit } = this.props
 
         return <Bloc className='pure-u-12-24'>
             <Form className='pure-form pure-form-stacked' onSubmit={ e => {
-                new Promise(resolve => resolve(handleOnSubmit(e, this.state)))
-                    .then(() => this.setState(GameForm.initialState))
+            	e.preventDefault()
+                handleOnSubmit({
+					title: this.state.gameTitle,
+					description: this.state.gameDescription,
+					price: this.state.gamePrice,
+					rating: this.state.gameRating,
+				})
+				this.setState(GameForm.initialState)
             } }>
                 <Title>Add a new Game</Title>
                 <fieldset>
@@ -36,28 +40,28 @@ export class GameForm extends React.Component {
                         type='text'
                         value={ this.state.gameTitle }
                         name='gameTitle'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Title'
                     />
                     <Input
                         type='text'
                         value={ this.state.gameDescription }
                         name='gameDescription'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Description'
                     />
                     <Input
                         type='number'
                         value={ this.state.gamePrice }
                         name='gamePrice'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Price'
                     />
                     <Input
                         type='number'
                         value={ this.state.gameRating }
                         name='gameRating'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Rating'
                     />
                     <Button type='submit'

--- a/src/core/components/exercice-14-A/Game/GameLibrary.jsx
+++ b/src/core/components/exercice-14-A/Game/GameLibrary.jsx
@@ -6,13 +6,19 @@ export class GameLibrary extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            games: this.props.games ? this.props.games : [],
+            games: [],
             error: ''
         }
     }
 
+    static getDerivedStateFromProps(nextProps, prevStates) {
+        return nextProps.games && prevStates.games !== nextProps.games ?
+            {games: nextProps.games} :
+            null;
+    }
+
     componentDidMount() {
-        if (this.props.games.length === 0) {
+        if (this.state.games.length === 0) {
             fetch('http://localhost:5010/api/games')
                 .then(response => response.json())
                 .then(games => this.setState({ games }))

--- a/src/core/components/exercice-14-A/Game/index.jsx
+++ b/src/core/components/exercice-14-A/Game/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bloc, GameForm, GameLibrary, GameList } from '../index';
+import {Bloc, GameForm, GameLibrary} from '../index';
 
 export class GameStore extends React.Component {
     constructor(props) {
@@ -11,13 +11,14 @@ export class GameStore extends React.Component {
         }
     }
 
-    onInputValueChange(event) {
-        this.setState({ [ event.target.name ]: event.target.value })
+    componentDidMount() {
+        fetch('http://localhost:5010/api/games')
+            .then(response => response.json())
+            .then(games => this.setState({games}))
+            .catch(error => this.setState({error: error}))
     }
 
-    onFormSubmit(e, values) {
-        e.preventDefault()
-
+    onFormSubmit = (values) => {
         fetch('/api/game', {
             method: 'POST',
             headers: {
@@ -35,9 +36,16 @@ export class GameStore extends React.Component {
 
         return (
             <Bloc className={ className }>
-                <GameLibrary games={ this.state.games }/>
-                <GameForm handleOnChange={ this.onInputValueChange }
-                          handleOnSubmit={ this.onFormSubmit.bind(this) }/>
+                {
+                    this.state.error !== '' ?
+                        <Bloc className="fetchError">An error occurred, please come back later</Bloc> :
+                        this.state.games.length > 0 ? <GameLibrary games={this.state.games} className='gameList'/>:
+                            <Bloc className="listEmpty">No games to show :/</Bloc>
+                }
+
+                    <GameForm handleOnSubmit={values => this.onFormSubmit(values)}/>
+
+
             </Bloc>);
     }
 }

--- a/src/core/components/exercice-14-B-correction/Game/GameForm.jsx
+++ b/src/core/components/exercice-14-B-correction/Game/GameForm.jsx
@@ -11,24 +11,28 @@ export class GameForm extends React.Component {
         return {
             gameTitle: '',
             gameDescription: '',
-            gamePlatforms: [],
-            gameDevelopers: [],
-            gameGenders: [],
             gamePrice: 0,
             gameRating: 0,
-            gameReleaseDate: '',
-            gameThumbnail: '',
-            gameUpdatedAt: '',
         };
     }
 
+	handleOnChange(event) {
+		this.setState({ [ event.target.name ]: event.target.value })
+	}
+
     render() {
-        const { handleOnChange, handleOnSubmit } = this.props
+        const { handleOnSubmit } = this.props
 
         return <Bloc className='pure-u-12-24'>
             <Form className='pure-form pure-form-stacked' onSubmit={ e => {
-                new Promise(resolve => resolve(handleOnSubmit(e, this.state)))
-                    .then(() => this.setState(GameForm.initialState))
+            	e.preventDefault()
+                handleOnSubmit({
+					title: this.state.gameTitle,
+					description: this.state.gameDescription,
+					price: this.state.gamePrice,
+					rating: this.state.gameRating,
+				})
+				this.setState(GameForm.initialState)
             } }>
                 <Title>Add a new Game</Title>
                 <fieldset>
@@ -36,28 +40,28 @@ export class GameForm extends React.Component {
                         type='text'
                         value={ this.state.gameTitle }
                         name='gameTitle'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Title'
                     />
                     <Input
                         type='text'
                         value={ this.state.gameDescription }
                         name='gameDescription'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Description'
                     />
                     <Input
                         type='number'
                         value={ this.state.gamePrice }
                         name='gamePrice'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Price'
                     />
                     <Input
                         type='number'
                         value={ this.state.gameRating }
                         name='gameRating'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Rating'
                     />
                     <Button type='submit'

--- a/src/core/components/exercice-14-B-correction/Game/GameLibrary.jsx
+++ b/src/core/components/exercice-14-B-correction/Game/GameLibrary.jsx
@@ -6,13 +6,19 @@ export class GameLibrary extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            games: this.props.games ? this.props.games : [],
+            games: [],
             error: ''
         }
     }
 
+    static getDerivedStateFromProps(nextProps, prevStates) {
+        return nextProps.games && prevStates.games !== nextProps.games ?
+            {games: nextProps.games} :
+            null;
+    }
+
     componentDidMount() {
-        if (this.props.games.length === 0) {
+        if (this.state.games.length === 0) {
             fetch('http://localhost:5010/api/games')
                 .then(response => response.json())
                 .then(games => this.setState({ games }))

--- a/src/core/components/exercice-14-B/Game/GameForm.jsx
+++ b/src/core/components/exercice-14-B/Game/GameForm.jsx
@@ -11,24 +11,28 @@ export class GameForm extends React.Component {
         return {
             gameTitle: '',
             gameDescription: '',
-            gamePlatforms: [],
-            gameDevelopers: [],
-            gameGenders: [],
             gamePrice: 0,
             gameRating: 0,
-            gameReleaseDate: '',
-            gameThumbnail: '',
-            gameUpdatedAt: '',
         };
     }
 
+	handleOnChange(event) {
+		this.setState({ [ event.target.name ]: event.target.value })
+	}
+
     render() {
-        const { handleOnChange, handleOnSubmit } = this.props
+        const { handleOnSubmit } = this.props
 
         return <Bloc className='pure-u-12-24'>
             <Form className='pure-form pure-form-stacked' onSubmit={ e => {
-                new Promise(resolve => resolve(handleOnSubmit(e, this.state)))
-                    .then(() => this.setState(GameForm.initialState))
+            	e.preventDefault()
+                handleOnSubmit({
+					title: this.state.gameTitle,
+					description: this.state.gameDescription,
+					price: this.state.gamePrice,
+					rating: this.state.gameRating,
+				})
+				this.setState(GameForm.initialState)
             } }>
                 <Title>Add a new Game</Title>
                 <fieldset>
@@ -36,28 +40,28 @@ export class GameForm extends React.Component {
                         type='text'
                         value={ this.state.gameTitle }
                         name='gameTitle'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Title'
                     />
                     <Input
                         type='text'
                         value={ this.state.gameDescription }
                         name='gameDescription'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Description'
                     />
                     <Input
                         type='number'
                         value={ this.state.gamePrice }
                         name='gamePrice'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Price'
                     />
                     <Input
                         type='number'
                         value={ this.state.gameRating }
                         name='gameRating'
-                        onChange={ handleOnChange.bind(this) }
+                        onChange={ this.handleOnChange.bind(this) }
                         placeholder='Rating'
                     />
                     <Button type='submit'

--- a/src/core/components/exercice-14-B/Game/GameLibrary.jsx
+++ b/src/core/components/exercice-14-B/Game/GameLibrary.jsx
@@ -6,13 +6,19 @@ export class GameLibrary extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            games: this.props.games ? this.props.games : [],
+            games: [],
             error: ''
         }
     }
 
+    static getDerivedStateFromProps(nextProps, prevStates) {
+        return nextProps.games && prevStates.games !== nextProps.games ?
+            {games: nextProps.games} :
+            null;
+    }
+
     componentDidMount() {
-        if (this.props.games.length === 0) {
+        if (this.state.games.length === 0) {
             fetch('http://localhost:5010/api/games')
                 .then(response => response.json())
                 .then(games => this.setState({ games }))

--- a/src/core/components/exercice-14-B/Game/index.jsx
+++ b/src/core/components/exercice-14-B/Game/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bloc, GameForm, GameLibrary, GameList } from '../index';
+import {Bloc, GameForm, GameLibrary} from '../index';
 
 export class GameStore extends React.Component {
     constructor(props) {
@@ -11,13 +11,14 @@ export class GameStore extends React.Component {
         }
     }
 
-    onInputValueChange(event) {
-        this.setState({ [ event.target.name ]: event.target.value })
+    componentDidMount() {
+        fetch('http://localhost:5010/api/games')
+            .then(response => response.json())
+            .then(games => this.setState({games}))
+            .catch(error => this.setState({error: error}))
     }
 
-    onFormSubmit(e, values) {
-        e.preventDefault()
-
+    onFormSubmit = (values) => {
         fetch('/api/game', {
             method: 'POST',
             headers: {
@@ -35,9 +36,16 @@ export class GameStore extends React.Component {
 
         return (
             <Bloc className={ className }>
-                <GameLibrary games={ this.state.games }/>
-                <GameForm handleOnChange={ this.onInputValueChange }
-                          handleOnSubmit={ this.onFormSubmit.bind(this) }/>
+                {
+                    this.state.error !== '' ?
+                        <Bloc className="fetchError">An error occurred, please come back later</Bloc> :
+                        this.state.games.length > 0 ? <GameLibrary games={this.state.games} className='gameList'/>:
+                            <Bloc className="listEmpty">No games to show :/</Bloc>
+                }
+
+                    <GameForm handleOnSubmit={values => this.onFormSubmit(values)}/>
+
+
             </Bloc>);
     }
 }


### PR DESCRIPTION
Fix: GameForm is broken since exercice-13

Confusion between `gameTitle` (state name) and `title` (query parameter name)
Use getDerivedStateFromProps, so that state is updated when user adds a new Game (passed as props from GameStore to GameLibrary)

Refactor: GameForm should handle its own states, i.e. :
 * it should handle `onChange` input events
 * it should correctly pass data to parent component via callback (confusion between state name and query parameter name)